### PR TITLE
Bump underscore from 1.4.4 to 1.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
   "bugs": {
     "url": "https://github.com/hajipy/embedded-queue/issues"
   },
-  "homepage": "https://github.com/hajipy/embedded-queue#readme"
+  "homepage": "https://github.com/hajipy/embedded-queue#readme",
+  "resolutions": {
+    "underscore": "^1.12.1"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4188,10 +4188,10 @@ typescript@4.2.x:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
   integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
-underscore@~1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
-  integrity sha1-YaajIBBiKvoHljvzJSA88SI51gQ=
+underscore@^1.12.1, underscore@~1.4.4:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.1.tgz#0c1c6bd2df54b6b69f2314066d65b6cde6fcf9d1"
+  integrity sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
- Bump underscore from 1.4.4 to 1.13.1

- [x] Run `yarn prepare`
